### PR TITLE
Fix typo in options documentation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emulatorjs.org",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "The EmulatorJS Website",
   "main": "index.js",
   "author": {

--- a/src/docs/Options.md
+++ b/src/docs/Options.md
@@ -213,7 +213,7 @@ EJS_Buttons = {
     quickSave: false,
     quickLoad: false,
     screenshot: false,
-    cacheManage: false
+    cacheManager: false
 }
 ```
 


### PR DESCRIPTION
### Description:

This pull request fixes a small typo in the documentation. The variable name `"cacheManage"` is misspelled in one of the examples. I have corrected the spelling to `"cacheManager"`.

### Changes Made:

- Fixed typo in example:  `"cacheManage"` -> `"cacheManager"`

### Testing:

This is a simple typo fix and does not require any testing.

(Yes this is a PR for 1 Character LOL)