### PR TITLE
Fix misspelt "virutal" to "virtual" for the Virtual Gamepad documentation

### DIFF
--- a/content/2.docs4devs/6.virtual-gamepad-settings.md
+++ b/content/2.docs4devs/6.virtual-gamepad-settings.md
@@ -1,5 +1,5 @@
 
-# Virutal Gamepad Settings
+# Virtual Gamepad Settings
 
 If you need another layout for the virtual gamepad, you can map it yourself.
 


### PR DESCRIPTION
Small quick spelling fix ;^)