### PR TITLE
Correct save-state-location code example on the Options page

### DIFF
--- a/content/1.docs/7.options.md
+++ b/content/1.docs/7.options.md
@@ -533,7 +533,7 @@ EJS_defaultOptions = {
 
 ### `EJS_DEBUG_XX`
 
-You can set this to `true` to enable debug mode. This will log a lot of information to the console and use the unminified scripts. This is useful for debugging issues with the emulator. And it is recommended to use this when you are contibuting to the project.
+You can set this to `true` to enable debug mode. This will log a lot of information to the console and use the unminified scripts. This is useful for debugging issues with the emulator. And it is recommended to use this when you are contributing to the project.
 
 - Type: `boolean`
 - Default: `false`

--- a/content/1.docs/7.options.md
+++ b/content/1.docs/7.options.md
@@ -525,7 +525,7 @@ Sets the default settings menu options.
 EJS_defaultOptions = {
     'shader':'crt-mattias.glslp',
     'save-state-slot': 4,
-    'save-state-location': 'keep in browser'
+    'save-state-location': 'browser'
 }
 ```
 


### PR DESCRIPTION
Currently, the `EJS_defaultOptions` section of the Options page includes `'save-state-location': 'keep in browser'` in the code example, which is no longer correct. This PR updates that line to the correct `'save-state-location': 'browser'` syntax.