### PR TITLE
Improve Compression from Generator

### DIFF
--- a/pages/editor.vue
+++ b/pages/editor.vue
@@ -58,12 +58,6 @@ definePageMeta({
                         <input type="checkbox" id="offline">
                         <span class="checkmark2"></span>
                     </label>
-                    <ul>
-                        <label class="container" id="singleFile" style="display:none;">Pack into single file
-                            <input type="checkbox" id="offlinePack">
-                            <span class="checkmark2"></span>
-                        </label>
-                    </ul>
                     <div id="pathToData">
                         <label class="container">Use Local path to Data
                             <input type="checkbox" id="p2d">

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -104,7 +104,7 @@ function editorMain() {
         let gameName = (document.getElementById('nameOfGame').value && document.getElementById('nameOfGame').value.trim() !== '') ? document.getElementById('nameOfGame').value : file.name;
         try {
             //let isChromebook = window.navigator.userAgent.includes("CrOS");
-            //window.sendLog("A user just generated a page with the EmulatorJS code helper.\n    Game Name: "+gameName+"\n    File name: "+file.name+"\n    System: "+window.selectedCoreData.core+"\n    Offline: "+(offline.checked ? (document.getElementById('offlinePack').checked ? "pack" : "yes") : "no")+"\n    Custom path to data: "+((document.getElementById('p2d').checked&&path2Data.value.trim()) ? path2Data.value : "no")+"\n    Ad Url: "+(document.getElementById('adUrl').value.trim() ? "<"+document.getElementById('adUrl').value.trim()+">" : "no")+"\n    Is Chromebook: "+(isChromebook ? "yes" : "no"));
+            //window.sendLog("A user just generated a page with the EmulatorJS code helper.\n    Game Name: "+gameName+"\n    File name: "+file.name+"\n    System: "+window.selectedCoreData.core+"\n    Offline: "+(offline.checked ? "pack" : "no")+"\n    Custom path to data: "+((document.getElementById('p2d').checked&&path2Data.value.trim()) ? path2Data.value : "no")+"\n    Ad Url: "+(document.getElementById('adUrl').value.trim() ? "<"+document.getElementById('adUrl').value.trim()+">" : "no")+"\n    Is Chromebook: "+(isChromebook ? "yes" : "no"));
         } catch (e) { }
         data['EJS_player'] = '#game';
         data['EJS_core'] = window.selectedCoreData.core;
@@ -136,7 +136,7 @@ function editorMain() {
         }
 
         let zipOut = true;
-        let fileData = '<html>\n    <head>\n        <!--HTML file auto generated using EmulatorJS codehelper-->\n        <style>\n            body, html {\n                margin: 0;\n                padding: 0;\n            }\n        </style>\n    </head>\n    <body>\n        <div style="width:100%;height:100%;max-width:100%">\n            <div id="game"></div>\n        </div>\n        <script>\n';
+        let fileData = '<html>\n    <head>\n        <!--HTML file auto generated using EmulatorJS codehelper-->\n        <style>\n            body, html {\n                margin: 0;\n                padding: 0;\n            }\n        </style>\n    </head>\n    <body>\n        <div style="width:100%;height:100%;max-width:100%">\n            <div id="game"></div>\n        </div>\n        <script type="module">\n';
         const spaces = '            ';
         if (!offline.checked) {
             if (stateOnLoad.files[0]) {
@@ -151,38 +151,30 @@ function editorMain() {
             }
             for (var k in data) {
                 if (data[k] === true || data[k] === false) {
-                    fileData += (spaces + k + ' = ' + data[k] + ';\n');
+                    fileData += (spaces + "window." + k + ' = ' + data[k] + ';\n');
                 } else {
-                    fileData += (spaces + k + ' = "' + data[k] + '";\n');
+                    fileData += (spaces + "window." + k + ' = "' + data[k] + '";\n');
                 }
             }
             fileData += '        </script>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></script>\n    </body>\n</html>';
-        } else if (document.getElementById('offlinePack').checked) {
-            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
-            var b = bytesToBase64(new Uint8Array(await (new Blob([file])).arrayBuffer()));
+        } else {
+            data['EJS_gameUrl'] = 'await new Response(new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))]).stream().pipeThrough(new DecompressionStream("gzip"))).blob()';
+            var b = bytesToBase64(new Uint8Array(await (await CompressBlob(new Blob([file]))).arrayBuffer()));
             var a = spaces + 'window.gameData = `' + b + '`;\n';
             fileData += a;
             for (var k in data) {
                 if (data[k] === true || data[k] === false || k === 'EJS_gameUrl') {
-                    fileData += (spaces + k + ' = ' + data[k] + ';\n');
+                    fileData += (spaces + "window." + k + ' = ' + data[k] + ';\n');
                 } else {
-                    fileData += (spaces + k + ' = "' + data[k] + '";\n');
+                    fileData += (spaces + "window." + k + ' = "' + data[k] + '";\n');
                 }
             }
-            fileData += '        </script>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></script>\n    </body>\n</html>';
+            fileData += `            let emulatorScript = document.createElement("script");
+            emulatorScript.type = 'text/javascript';
+            emulatorScript.src = '`+data['EJS_pathtodata']+`loader.js';
+            document.body.appendChild(emulatorScript);\n`
+            fileData += '        </script>\n    </body>\n</html>';
             zipOut = false;
-        } else {
-            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
-            var b = bytesToBase64(new Uint8Array(await (new Blob([file])).arrayBuffer()));
-            zip.file('gameData.js', 'window.gameData = `' + b + '`\n');
-            for (var k in data) {
-                if (data[k] === true || data[k] === false || k === 'EJS_gameUrl') {
-                    fileData += (spaces + k + ' = ' + data[k] + ';\n');
-                } else {
-                    fileData += (spaces + k + ' = \'' + data[k] + '\';\n');
-                }
-            }
-            fileData += '        </script>\n        <script src=\'' + data['EJS_pathtodata'] + 'loader.js\'></script>\n    </body>\n</html>';
         }
         if (zipOut === false) {
             document.getElementById('select2').style = 'display:none;';
@@ -271,4 +263,10 @@ function bytesToBase64(bytes) {
         String.fromCodePoint(byte),
     ).join("");
     return btoa(binString);
+}
+
+async function CompressBlob(blob) {
+    const cs = new CompressionStream("gzip");
+    const compressedStream = blob.stream().pipeThrough(cs);
+    return await new Response(compressedStream).blob();
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -158,9 +158,9 @@ function editorMain() {
             }
             fileData += '        </scr' + 'ipt>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></scr' + 'ipt>\n    </body>\n</html>';
         } else if (document.getElementById('offlinePack').checked) {
-            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(window.gameData)])';
-            var b = JSON.stringify(Array.from(new Uint8Array(await (new Blob([file])).arrayBuffer())));
-            var a = spaces + 'window.gameData = ' + b + ';\n';
+            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
+            var b = bytesToBase64(new Uint8Array(await (new Blob([file])).arrayBuffer()));
+            var a = spaces + 'window.gameData = `' + b + '`;\n';
             fileData += a;
             for (var k in data) {
                 if (data[k] === true || data[k] === false || k === 'EJS_gameUrl') {
@@ -172,9 +172,9 @@ function editorMain() {
             fileData += '        </scr' + 'ipt>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></scr' + 'ipt>\n    </body>\n</html>';
             zipOut = false;
         } else {
-            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(window.gameData)])';
-            var b = JSON.stringify(Array.from(new Uint8Array(await (new Blob([file])).arrayBuffer())));
-            zip.file('gameData.js', 'window.gameData = ' + b + '\n');
+            data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
+            var b = bytesToBase64(new Uint8Array(await (new Blob([file])).arrayBuffer()));
+            zip.file('gameData.js', 'window.gameData = `' + b + '`\n');
             for (var k in data) {
                 if (data[k] === true || data[k] === false || k === 'EJS_gameUrl') {
                     fileData += (spaces + k + ' = ' + data[k] + ';\n');
@@ -264,4 +264,11 @@ function copy(textareaId) {
     let textarea = document.getElementById(textareaId);
     textarea.select();
     document.execCommand('copy');
+}
+
+function bytesToBase64(bytes) {
+    const binString = Array.from(bytes, (byte) =>
+        String.fromCodePoint(byte),
+    ).join("");
+    return btoa(binString);
 }

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -156,7 +156,7 @@ function editorMain() {
                     fileData += (spaces + k + ' = "' + data[k] + '";\n');
                 }
             }
-            fileData += '        </scr' + 'ipt>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></scr' + 'ipt>\n    </body>\n</html>';
+            fileData += '        </script>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></script>\n    </body>\n</html>';
         } else if (document.getElementById('offlinePack').checked) {
             data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
             var b = bytesToBase64(new Uint8Array(await (new Blob([file])).arrayBuffer()));
@@ -169,7 +169,7 @@ function editorMain() {
                     fileData += (spaces + k + ' = "' + data[k] + '";\n');
                 }
             }
-            fileData += '        </scr' + 'ipt>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></scr' + 'ipt>\n    </body>\n</html>';
+            fileData += '        </script>\n        <script src="' + data['EJS_pathtodata'] + 'loader.js"></script>\n    </body>\n</html>';
             zipOut = false;
         } else {
             data['EJS_gameUrl'] = 'new Blob([Uint8Array.from(atob(window.gameData), (m) => m.codePointAt(0))])';
@@ -182,7 +182,7 @@ function editorMain() {
                     fileData += (spaces + k + ' = \'' + data[k] + '\';\n');
                 }
             }
-            fileData += '        </scr' + 'ipt>\n        <script src=\'' + data['EJS_pathtodata'] + 'loader.js\'></scr' + 'ipt>\n    </body>\n</html>';
+            fileData += '        </script>\n        <script src=\'' + data['EJS_pathtodata'] + 'loader.js\'></script>\n    </body>\n</html>';
         }
         if (zipOut === false) {
             document.getElementById('select2').style = 'display:none;';


### PR DESCRIPTION
This PR adds compression to the generated .html files using [the browser's built-in `gzip` compression/decompression routines](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API#browser_compatibility).

This brings what would have been a `53.35mb` .html on main (or a `21.85mb` .html with [#58](https://github.com/EmulatorJS/emulatorjs.org/issues/58) ) down to `16.32mb`.   This further compresses down to `12mb` if zipped.

Due to the async call needed for this, I made this a separate PR from #58 since the structure of the generated .html has changed to only load the emulator after the game data has been decompressed.   This is incompatible with the non-single-file-packing code, so it has been removed.

@allancoding