### PR TITLE
add `EJS_disableAutoLang`

### DIFF
--- a/content/1.docs/7.options.md
+++ b/content/1.docs/7.options.md
@@ -37,6 +37,12 @@ Set the emulator UI to a certian language. More information available [here](lan
 - Type: `string`
 - Default: `en-US`
 
+### `EJS_disableAutoLang`
+
+Set to `true` to disable the automatic language detection.
+
+- Type: `boolean`
+- Default: `false`
 
 ### `EJS_paths`
 


### PR DESCRIPTION
### `EJS_disableAutoLang`

Set to `true` to disable the automatic language detection.

- Type: `boolean`
- Default: `false`

See https://github.com/EmulatorJS/EmulatorJS/pull/1036 for more info.
